### PR TITLE
HCMS-1473 - Upgrade to java 8 for ps tools 8.56.06

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.cru.pshcm.addresscorrection</groupId>
   <artifactId>ps-address-correction-client</artifactId>
-  <version>1-SNAPSHOT</version>
+  <version>2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>address-correction-client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.cru.pshcm.addresscorrection</groupId>
   <artifactId>ps-address-correction-client</artifactId>
-  <version>2-SNAPSHOT</version>
+  <version>2</version>
   <packaging>jar</packaging>
 
   <name>address-correction-client</name>

--- a/src/assembly/dist.xml
+++ b/src/assembly/dist.xml
@@ -5,14 +5,6 @@
   </formats>
   <dependencySets>
     <dependencySet>
-      <excludes>
-        <!--
-          these are not used by us;
-          they are specified by a super-pom.
-        -->
-        <exclude>com.google.guava:guava</exclude>
-        <exclude>joda-time:joda-time</exclude>
-      </excludes>
       <unpack>false</unpack>
       <outputDirectory>lib</outputDirectory>
       <outputFileNameMapping>

--- a/src/main/java/org/cru/pshcm/addresscorrection/HttpsHandlerEnforcingHttpTransportPipe.java
+++ b/src/main/java/org/cru/pshcm/addresscorrection/HttpsHandlerEnforcingHttpTransportPipe.java
@@ -15,6 +15,9 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 
 /**
+ * A HttpTransportPipe that fixes broken EndpointAddress urls, if necessary.
+ * See HttpsHandlerEnforcingTransportTubeFactory for details.
+ *
  * @author Matt Drees
  */
 public class HttpsHandlerEnforcingHttpTransportPipe extends HttpTransportPipe

--- a/src/main/java/org/cru/pshcm/addresscorrection/HttpsHandlerEnforcingTransportTubeFactory.java
+++ b/src/main/java/org/cru/pshcm/addresscorrection/HttpsHandlerEnforcingTransportTubeFactory.java
@@ -4,8 +4,25 @@ import com.sun.istack.internal.NotNull;
 import com.sun.xml.internal.ws.api.pipe.ClientTubeAssemblerContext;
 import com.sun.xml.internal.ws.api.pipe.TransportTubeFactory;
 import com.sun.xml.internal.ws.api.pipe.Tube;
+import java.net.HttpURLConnection;
+import javax.net.ssl.HttpsURLConnection;
 
 /**
+ * This works around a peoplesoft JRE bug with https handling.
+ * The problem is with psft.pt8.pshttp.https.Handler#openConnection(URL, Proxy);
+ * it returns a {@link HttpURLConnection}, instead of a {@link HttpsURLConnection},
+ * when the url is an https url.
+ *
+ * This factory creates a HttpTransportPipe that uses reflection to replace
+ * the URLConnection, if necessary, for each request's
+ * {@link com.sun.xml.internal.ws.api.EndpointAddress}.
+ *
+ *
+ * This assumes that the JRE is an oracle JRE,
+ * that there is no security manager enforcement,
+ * and that the jax-ws library is the oracle built-in one.
+ *
+ *
  * @author Matt Drees
  */
 public class HttpsHandlerEnforcingTransportTubeFactory extends TransportTubeFactory


### PR DESCRIPTION
PeopleSoft Tools 8.56.06 runs jdk 1.8.0_144, so it can support Java 8 now.

Related to https://jira.cru.org/browse/HCMS-1473.

Related to https://github.com/CruGlobal/wsapi/pull/116 as well.
